### PR TITLE
Replace deprecated jquery method

### DIFF
--- a/jquery.sheetrock.js
+++ b/jquery.sheetrock.js
@@ -65,12 +65,12 @@
     $.fn.sheetrock.promise = $.fn.sheetrock.promise
 
       // Prefetch column labels.
-      .pipe(function() {
+      .then(function() {
         return _prefetch(options);
       })
 
       // Fetch data.
-      .pipe(function() {
+      .then(function() {
         return _fetch(options);
       });
 


### PR DESCRIPTION
According to the [jQuery documentation](http://api.jquery.com/deferred.pipe/), the `deferred.pipe` method is deprecated. One should use `deferred.then` instead.
