### PR TITLE
Use formatted cell values, if available

### DIFF
--- a/src/sheetrock.js
+++ b/src/sheetrock.js
@@ -187,7 +187,20 @@
 
   // Get the trimmed value of a cell object.
   var getCellValue = function (cell) {
-    var value = (cell && cell.v) ? cell.v : '';
+    var value;
+
+    // Use the formatted value, if available:
+    if (cell && cell.f) {
+      value = cell.f;
+    }
+    // Otherwise, use the raw value:
+    else if (cell && cell.v) {
+      value = cell.v;
+    }
+    else {
+      value = '';
+    }
+
     // Avoid array cell values.
     if (value instanceof Array) {
       value = cell.f || value.join('');


### PR DESCRIPTION
Made this tweak to get formatted values (cf. issue #74) where available rather than the raw data. Seems to work fine, though I'm not currently able to run the tests.